### PR TITLE
Use full-qualified task names

### DIFF
--- a/build-deploy-v2.yml
+++ b/build-deploy-v2.yml
@@ -53,7 +53,7 @@ jobs:
         displayName: "Script: List files"
         workingDirectory: $(TerraformSourceDirectory)
 
-      - task: TerraformInstaller@2
+      - task: JasonBJohnson.azure-pipelines-tasks-terraform.azure-pipelines-tasks-terraform-installer.TerraformInstaller@2
         displayName: "Terraform: Installer"
         inputs:
           terraformVersion: "latest"

--- a/destroy.yml
+++ b/destroy.yml
@@ -19,7 +19,7 @@ jobs:
       - script: echo "##vso[task.setvariable variable=TF_TOKEN_app_terraform_io]$(TF_TOKEN)"
         displayName: "Terraform Token"
 
-      - task: TerraformInstaller@2
+      - task: JasonBJohnson.azure-pipelines-tasks-terraform.azure-pipelines-tasks-terraform-installer.TerraformInstaller@2
         displayName: "Terraform: Installer"
         inputs:
           terraformVersion: "latest"
@@ -53,7 +53,7 @@ jobs:
       - script: echo "##vso[task.setvariable variable=TF_TOKEN_app_terraform_io]$(TF_TOKEN)"
         displayName: "Terraform Token"
 
-      - task: TerraformInstaller@2
+      - task: JasonBJohnson.azure-pipelines-tasks-terraform.azure-pipelines-tasks-terraform-installer.TerraformInstaller@2
         displayName: "Terraform: Installer"
         inputs:
           terraformVersion: "latest"

--- a/upgrade-part2.yml
+++ b/upgrade-part2.yml
@@ -27,7 +27,7 @@ jobs:
         displayName: "Script: List files"
         workingDirectory: $(TerraformSourceDirectory)
 
-      - task: TerraformInstaller@2
+      - task: JasonBJohnson.azure-pipelines-tasks-terraform.azure-pipelines-tasks-terraform-installer.TerraformInstaller@2
         displayName: "Terraform: Installer"
         inputs:
           terraformVersion: "latest"

--- a/upgrade.yml
+++ b/upgrade.yml
@@ -27,7 +27,7 @@ jobs:
         displayName: "Script: List files"
         workingDirectory: $(TerraformSourceDirectory)
 
-      - task: TerraformInstaller@2
+      - task: JasonBJohnson.azure-pipelines-tasks-terraform.azure-pipelines-tasks-terraform-installer.TerraformInstaller@2
         displayName: "Terraform: Installer"
         inputs:
           terraformVersion: "latest"


### PR DESCRIPTION
- Avoid ambiguous error because we also have the ms-devlabs extension installed too
